### PR TITLE
Move plugin and theme installation to parallel execution

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -31,6 +31,8 @@ class WordPressInstaller {
     // Create temp folder
     makeDir(this.tempDir);
 
+    const promises = [];
+
     // the default paths for the packages
     const defaultPaths = {
       rootFolder: this.rootFolder,
@@ -46,13 +48,16 @@ class WordPressInstaller {
 
     if (plugins) {
       const pluginPackages = plugins.map((plugin) => new PluginPackage(plugin, { ...defaultPaths, destFolder: this.pluginsFolder }));
-      await Promise.all(pluginPackages.map((pluginPackage) => pluginPackage.install()));
+      promises.push(...pluginPackages.map((pluginPackage) => pluginPackage.install()));
     }
 
     if (themes) {
       const themePackages = themes.map((theme) => new ThemePackage(theme, { ...defaultPaths, destFolder: this.themeFolder }));
-      await Promise.all(themePackages.map((themePackage) => themePackage.install()));
+      promises.push(...themePackages.map((themePackage) => themePackage.install()));
     }
+
+    // Install plugins and themes concurrently
+    await Promise.all(promises);
   }
 
   /**


### PR DESCRIPTION
Refactored the code in install.js to execute plugins and themes installation concurrently. Removed individual `Promise.all()` calls for each plugin and theme and instead created a single `Promise.all()` to handle all install promises. This will significantly increase the installation speed by running these processes parallelly instead of sequentially.

close #9