### PR TITLE
Add post-install commands

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -26,7 +26,7 @@ class WordPressInstaller {
    * @return {Promise} A promise that resolves when all the packages are installed.
    */
   async installPackages () {
-    const { wordpress, plugins, themes } = this.config;
+    const { wordpress, plugins, themes, postInstall } = this.config;
 
     // Create temp folder
     makeDir(this.tempDir);
@@ -52,6 +52,39 @@ class WordPressInstaller {
     if (themes) {
       const themePackages = themes.map((theme) => new ThemePackage(theme, { ...defaultPaths, destFolder: this.themeFolder }));
       await Promise.all(themePackages.map((themePackage) => themePackage.install()));
+    }
+
+    // Install plugins and themes concurrently
+    await Promise.all(promises);
+
+    // Run post-install commands
+    if (postInstall && postInstall.length > 0) {
+      console.log('🤖 Executing post-install commands...');
+      await this.runPostInstallCommands(postInstall);
+    }
+  }
+
+  /**
+   * Runs post-install commands asynchronously.
+   *
+   * @param {Array} commands - An array of WP-CLI commands to execute.
+   * @return {Promise<void>} - A promise that resolves when the post-install commands complete.
+   */
+  async runPostInstallCommands(commands) {
+    // Execute each post-install command
+    for (const command of commands) {
+      try {
+        console.log(`Executing: ${command}`);
+        const { stdout, stderr } = await exec(command);
+        if (stdout) {
+          console.log(`Command output:\n${stdout}`);
+        }
+        if (stderr) {
+          console.error(`Command error:\n${stderr}`);
+        }
+      } catch (error) {
+        console.error(`Error executing command: ${command}`, error);
+      }
     }
   }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { cleanup, makeDir } = require('./utils');
+const { cleanup, makeDir, isWPCLIAvailable} = require('./utils');
 const { WordPressPackage, PluginPackage, ThemePackage } = require('./package');
 
 /**
@@ -54,11 +54,8 @@ class WordPressInstaller {
       await Promise.all(themePackages.map((themePackage) => themePackage.install()));
     }
 
-    // Install plugins and themes concurrently
-    await Promise.all(promises);
-
     // Run post-install commands
-    if (postInstall && postInstall.length > 0) {
+    if (isWPCLIAvailable() && postInstall && postInstall.length > 0) {
       console.log('🤖 Executing post-install commands...');
       await this.runPostInstallCommands(postInstall);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -286,6 +286,23 @@ function replaceEmptySalts (configContent) {
   return configContent;
 }
 
+/**
+ * Checks if WP-CLI is available.
+ *
+ * @return {boolean} - A promise that resolves to true if WP-CLI is available, false otherwise.
+ */
+async function isWPCLIAvailable () {
+  try {
+    // Attempt to execute a simple WP-CLI command
+    await exec('wp --version');
+    return true; // If successful, WP-CLI is available
+  } catch (error) {
+    console.log('🔴 WP-CLI is not available on this system. Please install WP-CLI and try again.');
+    console.log('Read more about at https://make.wordpress.org/cli/handbook/guides/installing/');
+    return false; // If an error occurs, WP-CLI is not available
+  }
+}
+
 module.exports = {
   getConfig,
   makeDir,
@@ -299,5 +316,6 @@ module.exports = {
   installComposer,
   replaceDbConstant,
   replaceDbConstantBool,
-  replaceEmptySalts
+  replaceEmptySalts,
+  isWPCLIAvailable
 };


### PR DESCRIPTION
Added functionality to handle and run post-install commands after the packages installation. This includes the extraction of 'postInstall' from the config data, running post-install commands concurrently after plugins and themes installation, and a new method 'runPostInstallCommands' for executing these commands. This allows users to perform necessary actions automatically after the package installation process.

close #5