### PR TITLE
Update GitHub deployment method in jsDoc workflow

### DIFF
--- a/.github/workflows/jsDoc.yml
+++ b/.github/workflows/jsDoc.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
-        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs


### PR DESCRIPTION
Configuration in jsDoc.yml was adjusted. Instead of using the deploy_key for authentication during deployment, the process now utilizes built-in GITHUB_TOKEN for better security and simplicity.