### PR TITLE
Update jsdoc.json and jsDoc workflow for better config

### DIFF
--- a/.github/workflows/jsDoc.yml
+++ b/.github/workflows/jsDoc.yml
@@ -26,8 +26,13 @@ jobs:
         config_file: jsdoc.json
         front_page: readme.md
 
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Setup Pages
+      uses: actions/configure-pages@v2
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./out
+        # Upload entire repository
+        path: '.'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,19 +1,20 @@
 {
   "tags": {
     "allowUnknownTags": true,
-    "dictionaries": ["jsdoc"]
+    "dictionaries": ["jsdoc","closure"]
   },
   "typescript": {
     "moduleRoot": "lib"
   },
+  "sourceType": "module",
   "source": {
-    "include": ["lib", "package.json", "readme.md"],
+    "include": ["./lib", "package.json", "readme.md"],
     "includePattern": "\\.(jsx|js|ts|tsx)$",
     "excludePattern": "(^|\\/|\\\\)_"
   },
   "opts": {
     "encoding": "utf8",
-    "destination": "docs",
+    "destination": "./docs",
     "readme": "./readme.md",
     "recurse": true
   },


### PR DESCRIPTION
Updated jsdoc.json to include the 'closure' dictionary and specify the module's source type and paths more explicitly. In .github/workflows/jsDoc.yml, replaced peaceiris/actions-gh-pages with actions/configure-pages, actions/upload-pages-artifact, and actions/deploy-pages for a more secure and efficient deployment process using GITHUB_TOKEN.