### PR TITLE
Modify jsDoc workflow permissions for GITHUB_TOKEN use

### DIFF
--- a/.github/workflows/jsDoc.yml
+++ b/.github/workflows/jsDoc.yml
@@ -1,3 +1,8 @@
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 name: JSDoc Action
 
 on:


### PR DESCRIPTION
The change involves the update of permissions settings in the .github/workflows/jsDoc.yml file. Now, the JSDoc Action deployment process will utilize GITHUB_TOKEN for authentication, a method that enhances its security measures and simplifies the process as compared to the former dependency on the deploy_key.