### PR TITLE
Update GitHub deployment method in jsDoc workflow

### DIFF
--- a/.github/workflows/jsDoc.yml
+++ b/.github/workflows/jsDoc.yml
@@ -1,8 +1,4 @@
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
+# Simple workflow for deploying static content to GitHub Pages
 name: JSDoc Action
 
 on:
@@ -15,29 +11,50 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
-
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Checkout code
-      uses: actions/checkout@v4
+  # Single deploy job since we're just deploying
+  deploy:
+    name: Deploy
+    needs: build
 
-    - name: Build
-      uses: andstor/jsdoc-action@v1
-      with:
-        source_dir: ./lib
-        recurse: true
-        output_dir: ./out
-        config_file: jsdoc.json
-        front_page: readme.md
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
-    - name: Setup Pages
-      uses: actions/configure-pages@v2
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        # Upload entire repository
-        path: '.'
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v1
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        uses: andstor/jsdoc-action@v1
+        with:
+          source_dir: ./lib
+          recurse: true
+          output_dir: ./out
+          config_file: jsdoc.json
+          front_page: readme.md
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Configuration in jsDoc.yml was adjusted. Instead of using the deploy_key for authentication during deployment, the process now utilizes built-in GITHUB_TOKEN for better security and simplicity.