### PR TITLE
Rename jsDoc workflow to tsDoc and update configurations

### DIFF
--- a/.github/workflows/tsDoc.yml
+++ b/.github/workflows/tsDoc.yml
@@ -4,10 +4,6 @@ name: JSDoc Action
 on:
   release:
     branches: [ "master" ]
-  pull_request:
-    types: [ closed ]
-    branches:
-      - master
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -33,14 +29,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build Docs
-        uses: andstor/jsdoc-action@v1
+      - name: TypeDoc Action
+        uses: erikyo/tsdoc-action@v1
         with:
-          source_dir: ./lib
-          recurse: true
+          source_dir: ./src/*
           output_dir: ./docs
-          config_file: jsdoc.json
-          front_page: readme.md
+          front_page: README.md
 
       - name: Setup Pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
The jsDoc.yml file has been renamed to tsDoc.yml. The workflow configuration has been updated to focus on releases from the master branch only. Recursion is no longer enabled, and the TypeDoc Action is now used instead of jsDoc. Furthermore, configurations for output path, source directory, and front page have been adjusted.